### PR TITLE
fix: chat repository injection

### DIFF
--- a/app/src/main/java/com/shashank/anywheregpt/data/repositories/ChatRepository.kt
+++ b/app/src/main/java/com/shashank/anywheregpt/data/repositories/ChatRepository.kt
@@ -8,9 +8,9 @@ import javax.inject.Inject
 
 class ChatRepository @Inject constructor(
     private val api: ApiInterface
-) : SafeApiRequest() {
+) : SafeApiRequest(), IChatRepository {
 
-    suspend fun sendMessage(
+    override suspend fun sendMessage(
         chatPostBody: ChatPostBody
     ): ChatResponseBody = apiRequest {
         api.sendMessage(chatPostBody)

--- a/app/src/main/java/com/shashank/anywheregpt/data/repositories/IChatRepository.kt
+++ b/app/src/main/java/com/shashank/anywheregpt/data/repositories/IChatRepository.kt
@@ -1,0 +1,10 @@
+package com.shashank.anywheregpt.data.repositories
+
+import com.shashank.anywheregpt.data.models.ChatPostBody
+import com.shashank.anywheregpt.data.models.ChatResponseBody
+
+interface IChatRepository {
+    suspend fun sendMessage(
+        chatPostBody: ChatPostBody
+    ): ChatResponseBody
+}

--- a/app/src/main/java/com/shashank/anywheregpt/di/RepositoryModule.kt
+++ b/app/src/main/java/com/shashank/anywheregpt/di/RepositoryModule.kt
@@ -1,0 +1,22 @@
+package com.shashank.anywheregpt.di
+
+import com.shashank.anywheregpt.data.repositories.ChatRepository
+import com.shashank.anywheregpt.data.repositories.IChatRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+
+
+@Module
+@InstallIn(ViewModelComponent::class)
+abstract class RepositoryModule {
+
+    @ViewModelScoped
+    @Binds
+    abstract fun bindChatRepository(
+        chatRepository: ChatRepository,
+    ): IChatRepository
+
+}

--- a/app/src/main/java/com/shashank/anywheregpt/ui/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/shashank/anywheregpt/ui/viewmodels/ChatViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.shashank.anywheregpt.data.models.ChatPostBody
 import com.shashank.anywheregpt.data.models.ChatResponseBody
-import com.shashank.anywheregpt.data.repositories.ChatRepository
+import com.shashank.anywheregpt.data.repositories.IChatRepository
 import com.shashank.anywheregpt.utils.ChatRole
 import com.shashank.anywheregpt.utils.Event
 import com.shashank.anywheregpt.utils.State
@@ -18,7 +18,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
-class ChatViewModel @Inject constructor(private val repository: ChatRepository) :
+class ChatViewModel @Inject constructor(private val repository: IChatRepository) :
     ViewModel() {
 
 


### PR DESCRIPTION
In the code, there was a dependency upon implementation rather than abstraction, which makes the injection non-useful.
I fixed this problem by creating `IChatRepository` interface which I injected to the `ChatViewModel`, this way, it's much easier to replace the implementation of `ChatRepository` for the purposes of test, or in case of API errors. In my opinion, this modification enhances the testability and maintainability of the code.